### PR TITLE
force fetching of global_roles

### DIFF
--- a/app/views/users/_available_global_roles.html.erb
+++ b/app/views/users/_available_global_roles.html.erb
@@ -19,7 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ++#%>
 
 <% def available_additional_global_roles available_roles, user
-	available_roles - user.global_roles
+	available_roles - user.global_roles(true)
 end%>
 
 <div class="splitcontentright" id="available_principal_roles">


### PR DESCRIPTION
the global roles array is cached which leads to a wrong list of available roles for the user with leads to two failing cukes. let's fix that by force fetching them from the database.
