### PR TITLE
[21788] Design issues on roles and permissions (global roles plugin)

### DIFF
--- a/app/views/roles/_form.html.erb
+++ b/app/views/roles/_form.html.erb
@@ -50,11 +50,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 <% if role.new_record? || role.is_a?(GlobalRole) %>
   <div id="global_permissions" style=<%= role.new_record? && !role.is_a?(GlobalRole) ? "display:none" : ""%> >
-    <%= render :partial => "permissions", :locals => {:permissions => global_permissions, :role => role }%>
+    <%= render :partial => "permissions", :locals => {:permissions => global_permissions, :role => role, :globalRole => "true" }%>
   </div>
 <% end %>
 <% if role.new_record? || !role.is_a?(GlobalRole) %>
   <div id="member_permissions" style=<%= role.new_record? && role.is_a?(GlobalRole) ? "display:none" : ""%>>
-    <%= render :partial => "permissions", :locals => {:permissions => member_permissions, :role => role }%>
+    <%= render :partial => "permissions", :locals => {:permissions => member_permissions, :role => role, :globalRole => "false" }%>
   </div>
 <% end %>

--- a/app/views/roles/_form.html.erb
+++ b/app/views/roles/_form.html.erb
@@ -38,23 +38,23 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 <% if role.new_record? || role.is_a?(GlobalRole) %>
   <div id="global_attributes" style="display:none">
-    <%= render :partial => "global_attributes", :locals => { :f => f, :role => role, :roles => (roles.present? ? roles.select {|r| r.is_a?(GlobalRole)} : nil) }%>
+    <%= render partial: "global_attributes", locals: { f: f, role: role, roles: (roles.present? ? roles.select {|r| r.is_a?(GlobalRole)} : nil) }%>
   </div>
 <% end %>
 
 <% if role.new_record? || !role.is_a?(GlobalRole) %>
   <div id="member_attributes">
-    <%= render :partial => "member_attributes", :locals => { :f => f, :role => role, :roles => (roles.present? ? roles.select {|r| !r.is_a?(GlobalRole)} : nil)}%>
+    <%= render partial: "member_attributes", locals: { f: f, role: role, roles: (roles.present? ? roles.select {|r| !r.is_a?(GlobalRole)} : nil)}%>
   </div>
 <% end %>
 
 <% if role.new_record? || role.is_a?(GlobalRole) %>
   <div id="global_permissions" style=<%= role.new_record? && !role.is_a?(GlobalRole) ? "display:none" : ""%> >
-    <%= render :partial => "permissions", :locals => {:permissions => global_permissions, :role => role, :globalRole => "true" }%>
+    <%= render partial: "permissions", locals: {permissions: global_permissions, role: role, globalRole: "true" }%>
   </div>
 <% end %>
 <% if role.new_record? || !role.is_a?(GlobalRole) %>
   <div id="member_permissions" style=<%= role.new_record? && role.is_a?(GlobalRole) ? "display:none" : ""%>>
-    <%= render :partial => "permissions", :locals => {:permissions => member_permissions, :role => role, :globalRole => "false" }%>
+    <%= render partial: "permissions", locals: {permissions: member_permissions, role: role, globalRole: "false" }%>
   </div>
 <% end %>

--- a/app/views/roles/_form.html.erb
+++ b/app/views/roles/_form.html.erb
@@ -24,7 +24,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 <%= error_messages_for :role %>
 <div class="form--field">
-  <%= f.text_field :name, required: true %>
+  <%= f.text_field :name, required: true, container_class: '-slim' %>
 </div>
 <div class="form--field">
   <% if role.new_record? %>
@@ -48,7 +48,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </div>
 <% end %>
 
-<h3><%= l(:label_permissions) %></h3>
 <% if role.new_record? || role.is_a?(GlobalRole) %>
   <div id="global_permissions" style=<%= role.new_record? && !role.is_a?(GlobalRole) ? "display:none" : ""%> >
     <%= render :partial => "permissions", :locals => {:permissions => global_permissions, :role => role }%>

--- a/app/views/roles/_member_attributes.html.erb
+++ b/app/views/roles/_member_attributes.html.erb
@@ -24,6 +24,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <% if role.new_record? && roles.any? %>
   <div class="form--field">
     <%= styled_label_tag :copy_workflow_from, l(:label_copy_workflow_from) %>
-    <%= styled_select_tag(:copy_workflow_from, content_tag("option") + options_from_collection_for_select(@roles.select{|r| !r.is_a?(GlobalRole)}, :id, :name)) %>
+    <%= styled_select_tag(:copy_workflow_from, content_tag("option") + options_from_collection_for_select(@roles.select{|r| !r.is_a?(GlobalRole)}, :id, :name), container_class: '-slim') %>
   </div>
 <% end %>

--- a/app/views/roles/_permissions.html.erb
+++ b/app/views/roles/_permissions.html.erb
@@ -20,13 +20,16 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 <% perms_by_module = permissions.group_by {|p| p.project_module.to_s} %>
 <% perms_by_module.keys.sort.each do |mod| %>
-  <fieldset><legend><%= mod.blank? ? Project.model_name.human : l_or_humanize(mod, :prefix => 'project_module_') %></legend>
-  <% perms_by_module[mod].each do |permission| %>
-      <label class="floating form--label">
-        <%= check_box_tag 'role[permissions][]', permission.name, (role.permissions && role.permissions.include?(permission.name)) %>
-        <%= l_or_humanize(permission.name, :prefix => 'permission_') %>
-      </label>
-  <% end %>
+  <fieldset class="form--fieldset">
+    <legend class="form--fieldset-legend">
+      <%= mod.blank? ? Project.model_name.human : l_or_humanize(mod, :prefix => 'project_module_') %>
+    </legend>
+    <% perms_by_module[mod].each do |permission| %>
+        <label class="floating form--label">
+          <%= check_box_tag 'role[permissions][]', permission.name, (role.permissions && role.permissions.include?(permission.name)) %>
+          <%= l_or_humanize(permission.name, :prefix => 'permission_') %>
+        </label>
+    <% end %>
   </fieldset>
 <% end %>
 <br /><%= check_all_links permissions_id(permissions) %>

--- a/app/views/roles/_permissions.html.erb
+++ b/app/views/roles/_permissions.html.erb
@@ -20,7 +20,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 <% perms_by_module = permissions.group_by {|p| p.project_module.to_s} %>
 <% perms_by_module.keys.sort.each do |mod| %>
-  <fieldset class="form--fieldset">
+  <% if globalRole === 'false' %>
+    <fieldset class="form--fieldset" id="<%= mod.blank? ? 'fieldset--' + Project.model_name.human.downcase.gsub(' ', '_') : 'fieldset--' + l_or_humanize(mod, :prefix => 'project_module_').downcase.gsub(' ', '_') %>">
+  <% else %>
+    <fieldset class="form--fieldset" id="<%= mod.blank? ? 'fieldset--global--' + Project.model_name.human.downcase.gsub(' ', '_') : 'fieldset--global--' + l_or_humanize(mod, :prefix => 'project_module_').downcase.gsub(' ', '_') %>">
+  <% end %>
+
     <legend class="form--fieldset-legend">
       <%= mod.blank? ? Project.model_name.human : l_or_humanize(mod, :prefix => 'project_module_') %>
     </legend>
@@ -30,7 +35,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           <%= l_or_humanize(permission.name, :prefix => 'permission_') %>
         </label>
     <% end %>
+
+    <% if globalRole === 'false' %>
+      <br /><%= check_all_links (mod.blank? ? 'fieldset--' + Project.model_name.human.downcase.gsub(' ', '_') : 'fieldset--' + l_or_humanize(mod, :prefix => 'project_module_').downcase.gsub(' ', '_')) %>
+    <% else %>
+      <br /><%= check_all_links (mod.blank? ? 'fieldset--global--' + Project.model_name.human.downcase.gsub(' ', '_') : 'fieldset--global--' + l_or_humanize(mod, :prefix => 'project_module_').downcase.gsub(' ', '_')) %>
+    <% end %>
+
   </fieldset>
 <% end %>
-<br /><%= check_all_links permissions_id(permissions) %>
 <%= hidden_field_tag 'role[permissions][]', '' %>

--- a/app/views/roles/_permissions.html.erb
+++ b/app/views/roles/_permissions.html.erb
@@ -21,25 +21,25 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <% perms_by_module = permissions.group_by {|p| p.project_module.to_s} %>
 <% perms_by_module.keys.sort.each do |mod| %>
   <% if globalRole === 'false' %>
-    <fieldset class="form--fieldset" id="<%= mod.blank? ? 'fieldset--' + Project.model_name.human.downcase.gsub(' ', '_') : 'fieldset--' + l_or_humanize(mod, :prefix => 'project_module_').downcase.gsub(' ', '_') %>">
+    <fieldset class="form--fieldset" id="<%= mod.blank? ? 'fieldset--' + Project.model_name.human.downcase.gsub(' ', '_') : 'fieldset--' + l_or_humanize(mod, prefix: 'project_module_').downcase.gsub(' ', '_') %>">
   <% else %>
-    <fieldset class="form--fieldset" id="<%= mod.blank? ? 'fieldset--global--' + Project.model_name.human.downcase.gsub(' ', '_') : 'fieldset--global--' + l_or_humanize(mod, :prefix => 'project_module_').downcase.gsub(' ', '_') %>">
+    <fieldset class="form--fieldset" id="<%= mod.blank? ? 'fieldset--global--' + Project.model_name.human.downcase.gsub(' ', '_') : 'fieldset--global--' + l_or_humanize(mod, prefix: 'project_module_').downcase.gsub(' ', '_') %>">
   <% end %>
 
     <legend class="form--fieldset-legend">
-      <%= mod.blank? ? Project.model_name.human : l_or_humanize(mod, :prefix => 'project_module_') %>
+      <%= mod.blank? ? Project.model_name.human : l_or_humanize(mod, prefix: 'project_module_') %>
     </legend>
     <% perms_by_module[mod].each do |permission| %>
         <label class="floating form--label">
           <%= check_box_tag 'role[permissions][]', permission.name, (role.permissions && role.permissions.include?(permission.name)) %>
-          <%= l_or_humanize(permission.name, :prefix => 'permission_') %>
+          <%= l_or_humanize(permission.name, prefix: 'permission_') %>
         </label>
     <% end %>
 
     <% if globalRole === 'false' %>
-      <br /><%= check_all_links (mod.blank? ? 'fieldset--' + Project.model_name.human.downcase.gsub(' ', '_') : 'fieldset--' + l_or_humanize(mod, :prefix => 'project_module_').downcase.gsub(' ', '_')) %>
+      <br /><%= check_all_links (mod.blank? ? 'fieldset--' + Project.model_name.human.downcase.gsub(' ', '_') : 'fieldset--' + l_or_humanize(mod, prefix: 'project_module_').downcase.gsub(' ', '_')) %>
     <% else %>
-      <br /><%= check_all_links (mod.blank? ? 'fieldset--global--' + Project.model_name.human.downcase.gsub(' ', '_') : 'fieldset--global--' + l_or_humanize(mod, :prefix => 'project_module_').downcase.gsub(' ', '_')) %>
+      <br /><%= check_all_links (mod.blank? ? 'fieldset--global--' + Project.model_name.human.downcase.gsub(' ', '_') : 'fieldset--global--' + l_or_humanize(mod, prefix: 'project_module_').downcase.gsub(' ', '_')) %>
     <% end %>
 
   </fieldset>


### PR DESCRIPTION
This PR deals with design issues on the admin page for roles and permissions.
- [x] correct use of field sets
- [x] shortened field for role name
- [x] enable '(un-)check all' - functionality for every fieldset

https://community.openproject.org/work_packages/21788/activity

**Note** This only changes the site for the plugin. In the core there is a similar site which already uses the correct classes, but is differently styled. That is why the core is out of scope for this PR. 
