### PR TITLE
[21888] Missing content message

### DIFF
--- a/app/assets/javascripts/global_roles/principal_roles.js
+++ b/app/assets/javascripts/global_roles/principal_roles.js
@@ -25,12 +25,12 @@
 
     set_table_visibility: function(){
       if ($('#table_principal_roles_body tr').length > 0){
-        $('#table_principal_roles').show();
+        $('.generic-table--results-container').show();
         $('.generic-table--no-results-container').hide();
       }
       else
       {
-        $('#table_principal_roles').hide();
+        $('.generic-table--results-container').hide();
         $('.generic-table--no-results-container').show();
       }
     },

--- a/app/views/users/_global_roles.html.erb
+++ b/app/views/users/_global_roles.html.erb
@@ -58,7 +58,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           <%= l(:label_nothing_display) %>
         </h2>
         <div class="generic-table--no-results-description">
-          <p>Either nothing have been created or everything is filtered out.</p>
+          <p class="nodata"><%= l(:label_no_data) %></p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This hides the results container instead of the table. Thus it is avoided that parts of it can still be seen or overlap the no-result-container (Chrome or IE).
Further the for the text a given label is used.

https://community.openproject.org/work_packages/21888/activity
