### PR TITLE
Show and hide the results container

### DIFF
--- a/app/assets/javascripts/global_roles/principal_roles.js
+++ b/app/assets/javascripts/global_roles/principal_roles.js
@@ -25,12 +25,12 @@
 
     set_table_visibility: function(){
       if ($('#table_principal_roles_body tr').length > 0){
-        $('#table_principal_roles').show();
+        $('.generic-table--results-container').show();
         $('.generic-table--no-results-container').hide();
       }
       else
       {
-        $('#table_principal_roles').hide();
+        $('.generic-table--results-container').hide();
         $('.generic-table--no-results-container').show();
       }
     },
@@ -46,7 +46,7 @@
         $('#no_additional_principal_roles').show();
       }
     }
-  }
+  };
 
   $(document).ready(function () {
     $(document).ajaxStop(principal_roles.init);

--- a/spec/models/global_role_spec.rb
+++ b/spec/models/global_role_spec.rb
@@ -20,13 +20,13 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe GlobalRole, type: :model do
-  before { GlobalRole.create name: 'globalrole', permissions: ['permissions'] } # for validate_uniqueness_of
+  before { GlobalRole.create name: 'globalrole', permissions: ['permissions'] }
 
   it { is_expected.to have_many :principals }
   it { is_expected.to have_many :principal_roles }
   it { is_expected.to validate_presence_of :name }
   it { is_expected.to validate_uniqueness_of :name }
-  it { is_expected.to ensure_length_of(:name).is_at_most(30) }
+  it { is_expected.to validate_length_of(:name).is_at_most(30) }
 
   describe 'attributes' do
     before { @role = GlobalRole.new }


### PR DESCRIPTION
This fixes a markup bug in firefox where the no-results container
was not visible after the last global role was removed.
