### PR TITLE
[22040] Apply new icon styling (Global roles)

### DIFF
--- a/app/views/roles/edit.html.erb
+++ b/app/views/roles/edit.html.erb
@@ -27,5 +27,5 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <%= render :partial => 'form', :locals => { :f => f , :role => @role, :member_permissions => (@role.is_a?(GlobalRole) ? nil : @permissions),
 :global_permissions => (@role.is_a?(GlobalRole) ? @permissions : nil)} %>
 <br/>
-<%= styled_button_tag l(:button_save), class: '-with-icon icon-yes' %>
+<%= styled_button_tag l(:button_save), class: '-with-icon icon-checkmark' %>
 <% end %>

--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -74,7 +74,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               <%= content_tag(role.builtin? ? 'em' : 'span', link_to(role.name, :action => 'edit', :id => role)) %>
             </td>
             <td>
-              <%= icon_wrapper('icon-context icon-yes', I18n.t(:general_text_Yes)) if role.is_a?(GlobalRole) %>
+              <%= icon_wrapper('icon-context icon-checkmark', I18n.t(:general_text_Yes)) if role.is_a?(GlobalRole) %>
             </td>
             <td>
               <% unless role.builtin? %>

--- a/app/views/roles/new.html.erb
+++ b/app/views/roles/new.html.erb
@@ -25,5 +25,5 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <%= labelled_tabular_form_for @role, :url => { :action => 'create' }, :html => {:id => 'role_form'}, :as => :role do |f| %>
 <%= render :partial => 'form', :locals => { :f => f, :role => @role, :member_role => @member_role, :global_role => @global_role, :roles => @roles,  :member_permissions => @member_permissions, :global_permissions => @global_permissions} %>
 <br/>
-<%= styled_button_tag l(:button_create), class: '-with-icon icon-yes' %>
+<%= styled_button_tag l(:button_create), class: '-with-icon icon-checkmark' %>
 <% end %>

--- a/app/views/users/_available_global_roles.html.erb
+++ b/app/views/users/_available_global_roles.html.erb
@@ -30,7 +30,7 @@ end%>
 <% available_additional_global_roles(global_roles, user).each do |role| %>
   <%= render :partial => 'users/available_global_role', :locals => {:role => role} %>
 <% end %>
-<p><br/><%= styled_button_tag l(:button_add), class: '-with-icon icon-yes' %></p>
+<p><br/><%= styled_button_tag l(:button_add), class: '-with-icon icon-checkmark' %></p>
 <% end %>
 </span>
 <span id="no_additional_principal_roles" style="display:none">

--- a/app/views/users/_global_roles.html.erb
+++ b/app/views/users/_global_roles.html.erb
@@ -54,7 +54,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       </div>
       <div class="generic-table--no-results-container">
         <h2 class="generic-table--no-results-title">
-          <i class="icon-info"></i>
+          <i class="icon-info1"></i>
           <%= l(:label_nothing_display) %>
         </h2>
         <div class="generic-table--no-results-description">


### PR DESCRIPTION
This applies the new icon styling in the plugin. Note that this only works in combination with opf/openproject#3815 since there the icon font is updated.

https://community.openproject.org/work_packages/22040/activity
