### PR TITLE
[21858] Wrong positioning of (un)check all in permissions view (global roles plugin)

### DIFF
--- a/app/views/roles/_permissions.html.erb
+++ b/app/views/roles/_permissions.html.erb
@@ -21,26 +21,31 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <% perms_by_module = permissions.group_by {|p| p.project_module.to_s} %>
 <% perms_by_module.keys.sort.each do |mod| %>
   <% if globalRole === 'false' %>
-    <fieldset class="form--fieldset" id="<%= mod.blank? ? 'fieldset--' + Project.model_name.human.downcase.gsub(' ', '_') : 'fieldset--' + l_or_humanize(mod, prefix: 'project_module_').downcase.gsub(' ', '_') %>">
+    <% module_name = mod.blank? ? 'fieldset--' + Project.model_name.human.downcase.gsub(' ', '_') : 'fieldset--' + l_or_humanize(mod, prefix: 'project_module_').downcase.gsub(' ', '_') %>
+    <fieldset class="form--fieldset -collapsible" id="<%= module_name %>">
   <% else %>
-    <fieldset class="form--fieldset" id="<%= mod.blank? ? 'fieldset--global--' + Project.model_name.human.downcase.gsub(' ', '_') : 'fieldset--global--' + l_or_humanize(mod, prefix: 'project_module_').downcase.gsub(' ', '_') %>">
+    <% module_name = mod.blank? ? 'fieldset--global--' + Project.model_name.human.downcase.gsub(' ', '_') : 'fieldset--global--' + l_or_humanize(mod, prefix: 'project_module_').downcase.gsub(' ', '_') %>
+    <fieldset class="form--fieldset -collapsible" id="<%= module_name %>">
   <% end %>
 
-    <legend class="form--fieldset-legend">
+    <legend class="form--fieldset-legend" onclick="toggleFieldset(this);">
       <%= mod.blank? ? Project.model_name.human : l_or_humanize(mod, prefix: 'project_module_') %>
     </legend>
+    <div class="form--fieldset-control">
+      <span class="form--fieldset-control-container">
+        (<%= check_all_links module_name %>)
+      </span>
+    </div>
     <% perms_by_module[mod].each do |permission| %>
+      <div class="autoscroll">
         <label class="floating form--label">
           <%= check_box_tag 'role[permissions][]', permission.name, (role.permissions && role.permissions.include?(permission.name)) %>
           <%= l_or_humanize(permission.name, prefix: 'permission_') %>
         </label>
+      </div>
     <% end %>
 
-    <% if globalRole === 'false' %>
-      <br /><%= check_all_links (mod.blank? ? 'fieldset--' + Project.model_name.human.downcase.gsub(' ', '_') : 'fieldset--' + l_or_humanize(mod, prefix: 'project_module_').downcase.gsub(' ', '_')) %>
-    <% else %>
-      <br /><%= check_all_links (mod.blank? ? 'fieldset--global--' + Project.model_name.human.downcase.gsub(' ', '_') : 'fieldset--global--' + l_or_humanize(mod, prefix: 'project_module_').downcase.gsub(' ', '_')) %>
-    <% end %>
+
 
   </fieldset>
 <% end %>


### PR DESCRIPTION
This changes the styling of permissions site so that each group has its own Check-All functionality. The core styling is changed in https://github.com/opf/openproject/pull/4031

https://community.openproject.org/work_packages/21858/activity
