### PR TITLE
[22621] Warning message not shown when deleting role

### DIFF
--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -83,9 +83,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             </td>
             <td class="buttons">
               <%= link_to(l(:button_delete), role_path(role),
-                                       :method => :delete,
-                                       :confirm => l(:text_are_you_sure),
-                                       :class => 'icon icon-delete') unless role.builtin? %>
+                                       method: :delete,
+                                       data: { confirm: l(:text_are_you_sure) },
+                                       class: 'icon icon-delete') unless role.builtin? %>
             </td>
           </tr>
         <% end %>


### PR DESCRIPTION
This corrects the alert call. Thus a warning message is shown before the role can be deleted.

https://community.openproject.org/work_packages/22621/activity
