### PR TITLE
[23980] Add buttons are not consistently used (Global Roles)

### DIFF
--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -20,8 +20,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <% html_title l(:label_administration), l("label_role_plural") %>
 <%= toolbar title: Role.model_name.human(count: 2) do %>
   <li class="toolbar-item">
-    <%= link_to({ action: 'new'}, class: 'button -alt-highlight') do %>
-      <i class="button--icon icon-add"></i> <%= l(:label_role_new) %>
+    <%= link_to({ action: 'new'},
+          { class: 'button -alt-highlight',
+            aria: {label: t(:label_role_new)},
+            title: t(:label_role_new)}) do %>
+      <i class="button--icon icon-add"></i>
+      <span class="button--text"><%= Role.model_name.human %></span>
     <% end %>
   </li>
 <% end %>


### PR DESCRIPTION
The makes the use of 'add' buttons consistent.

https://community.openproject.com/work_packages/23980/activity

Related PRs:
- https://github.com/finnlabs/openproject-backlogs/pull/230
- https://github.com/finnlabs/openproject-my_project_page/pull/83
- https://github.com/opf/openproject-documents/pull/64
- https://github.com/finnlabs/openproject-meeting/pull/133
- https://github.com/finnlabs/openproject-pdf_export/pull/53
  https://github.com/opf/openproject/pull/4879
