### PR TITLE
[23995] Apply multiple columns at Admin/Roles page (2)

### DIFF
--- a/app/views/roles/_permissions.html.erb
+++ b/app/views/roles/_permissions.html.erb
@@ -38,12 +38,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </div>
     <div class="-columns-2">
       <% perms_by_module[mod].each do |permission| %>
-        <div class="form--field autoscroll -trailing-label ">
-          <label class="form--label">
-            <%= l_or_humanize(permission.name, prefix: 'permission_') %>
-          </label>
+        <div class="form--field">
           <div class="form--field-container">
-            <%= styled_check_box_tag 'role[permissions][]', permission.name, (role.permissions && role.permissions.include?(permission.name)) %>
+            <label class="form--label-with-check-box">
+              <%= styled_check_box_tag 'role[permissions][]', permission.name, (role.permissions && role.permissions.include?(permission.name)) %>
+              <%= l_or_humanize(permission.name, prefix: 'permission_') %>
+            </label>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
With the new implementation of the checkboxes in Admin/Roles there were some minor styling issues. These occurred because of a false usage of the `trailing-label` class. This PR changes the implementation to the `label-with-checkbox` class. 

https://community.openproject.com/work_packages/23995/activity

**Related** https://github.com/opf/openproject/pull/4910
